### PR TITLE
Restructured and added CentOS 7 support.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,7 @@ platforms:
 - name: ubuntu-12.04
   run_list:
   - recipe[apt]
+- name: centos-7.1
 suites:
 - name: default
   run_list:

--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,5 @@ metadata
 
 group :integration do
   cookbook 'apt'
-  cookbook 'snort'
+  cookbook 'snort', git: 'git@github.com:dcode/snort-cookbook.git', branch: 'topic/dcode/better_rhel_support'
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,13 +16,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+case node['platform_family']
+when 'debian'
+  default['pulledpork']['dependencies'] = %w(libcrypt-ssleay-perl liblwp-useragent-determined-perl)
+  default['pulledpork']['snort_svc_name'] = 'snort'
+when 'rhel'
+  default['pulledpork']['dependencies'] = %w(perl-libwww-perl perl-Crypt-SSLeay perl-Archive-Tar perl-Sys-Syslog perl-LWP-Protocol-https)
+  default['pulledpork']['snort_svc_name'] = 'snortd'
+end
 
-default['pulledpork']['version'] = '0.7.0'
+default['pulledpork']['version'] = '0.7.2'
 default['pulledpork']['pp_config_path'] = '/etc/snort/pulledpork.conf'
-default['pulledpork']['artifact_url'] = 'https://pulledpork.googlecode.com/files/pulledpork-0.7.0.tar.gz'
+default['pulledpork']['artifact_url'] =
+  'https://github.com/shirkdog/pulledpork/archive/' +
+  node['pulledpork']['version'] + '.tar.gz'
 
 # without any rule_urls defined in this array pulled pork will fail to run
-default['pulledpork']['rule_url_array'] = []
+default['pulledpork']['rule_url_array'] = [
+
+]
 
 # this is an array of hashes that contains the disable rule as the key and a comment as the value.
 # Example [{'129:4:1' => 'TCP Timestamp is outside of PAWS window'}]
@@ -37,7 +49,7 @@ default['pulledpork']['sid_changelog'] = '/var/log/snort/sid_changes.log'
 default['pulledpork']['snort_path'] = '/usr/sbin/snort'
 default['pulledpork']['config_path'] = '/etc/snort/snort.conf'
 default['pulledpork']['sorule_path'] = '/usr/lib/snort_dynamicrules/'
-default['pulledpork']['distro'] = 'Ubuntu-10-4'
+default['pulledpork']['distro'] = '' # Default to empty since there are only ancient distros here
 default['pulledpork']['black_list'] = '/etc/snort/rules/iplists/default.blacklist'
 default['pulledpork']['IPRVersion'] = '/etc/snort/rules/iplists'
 default['pulledpork']['disablesid'] = '/etc/snort/disablesid.conf'

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -1,0 +1,34 @@
+
+template node['pulledpork']['disablesid'] do
+  source 'disablesid.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0640'
+  notifies :run, 'bash[run_pulledpork]'
+  not_if { node['pulledpork']['disabled_sids_hash_array'].empty? }
+end
+
+template node['pulledpork']['pp_config_path'] do
+  source 'pulledpork.conf.erb'
+  owner 'root'
+  group 'root'
+  mode '0640'
+  notifies :run, 'bash[run_pulledpork]'
+end
+
+# create the sorule_path unless its managed elsewhere
+directory node['pulledpork']['sorule_path'] do
+  owner 'root'
+  group 'root'
+  mode '0755'
+  not_if { ::File.exist?(node['pulledpork']['sorule_path']) }
+end
+
+# pulled pork fails if a so rule doesn't exist in the dir.
+cookbook_file '/usr/lib/snort_dynamicrules/os-linux.so' do
+  source 'default_so_rule'
+  action :create_if_missing
+  owner 'root'
+  group 'root'
+  mode '0655'
+end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,0 +1,15 @@
+
+
+# install packages needed by pulledpork
+package node['pulledpork']['dependencies']
+
+ark 'pulledpork' do
+  url node['pulledpork']['artifact_url']
+  version node['pulledpork']['version']
+  has_binaries %w(pulledpork.pl)
+end
+
+# fix bad permissions in the tarball
+file "/usr/local/pulledpork-#{node['pulledpork']['version']}/pulledpork.pl" do
+  mode '0755'
+end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -1,0 +1,7 @@
+
+
+cron 'pulledpork' do
+  hour '12'
+  minute '0'
+  command "/usr/local/bin/pulledpork.pl -c #{node['pulledpork']['pp_config_path']} -l && service #{node['pulledpork']['snort_svc_name']} restart"
+end


### PR DESCRIPTION
- Split default recipe into components, allowing a user to choose which steps to
  use in wrapper cookbooks.
- Added some platform-dependent logic to enable Debian and RHEL-based systems

My branch of the snort cookbook is necessary until the pending PR upstream is complete.
